### PR TITLE
Fix incorrect links on contact us and resources page

### DIFF
--- a/src/pages/ContactUs.tsx
+++ b/src/pages/ContactUs.tsx
@@ -6,7 +6,7 @@ function ContactUs() {
   const socials = [
     {
       svg: "/icons/discord.svg",
-      link: "https://discord.gg/",
+      link: "https://discord.gg/UZXpqynDzt",
       name: "Discord",
       social: "CareTech@UCI",
     },
@@ -18,7 +18,7 @@ function ContactUs() {
     },
     {
       svg: "/icons/linkedin.svg",
-      link: "https://www.linkedin.com/company/",
+      link: "https://www.linkedin.com/company/caretech-uci/posts/?feedView=all",
       name: "LinkedIn",
       social: "UCI CareTech",
     },

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -39,7 +39,7 @@ function Resources() {
           <p className="text-secondary p-8 text-xl sm:text-2xl font-montserrat">
             Check out our {" "}
             <Link
-                to=""
+                to="/ContactUs"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-[#0097FC] font-bold"


### PR DESCRIPTION
- Discord and LinkedIn link placeholders replaced with proper links
- Placeholder link on resources page replaced with link to /ContactUs